### PR TITLE
Fixed: __add__ of PiCN.Packets.Name acted in-place.

### DIFF
--- a/PiCN/Packets/Name.py
+++ b/PiCN/Packets/Name.py
@@ -1,5 +1,7 @@
 """Internal representation of network name"""
 
+from typing import List, Union
+
 import binascii
 import json
 import os
@@ -9,11 +11,14 @@ class Name(object):
     Internal representation of network name
     """
 
-    def __init__(self, name: str = None, suite='ndn2013'):
+    def __init__(self, name: Union[str, List[bytes]] = None, suite='ndn2013'):
         self.suite = suite
         self.digest = None
         if name:
-            self.from_string(name)
+            if isinstance(name, str):
+                self.from_string(name)
+            else:
+                self._components = name
         else:
             self._components = []
 
@@ -68,15 +73,49 @@ class Name(object):
             return False
         return self.to_string() == other.to_string()
 
-    def __add__(self, comp_s):
+    def __add__(self, other) -> 'Name':
+        components: List[bytes] = []
+        for c in self._components:
+            components.append(c)
+        if type(other) is list:
+            for comp in other:
+                if type(comp) is str:
+                    components.append(comp.encode('ascii'))
+                elif type(comp) is bytes:
+                    components.append(comp)
+                else:
+                    raise TypeError('Not a Name, str, List[str] or List[bytes]')
+        elif type(other) is str:
+            o = Name(other)
+            for comp in o._components:
+                components.append(comp)
+        elif isinstance(other, Name):
+            for comp in other._components:
+                components.append(comp)
+        else:
+            raise TypeError('Not a Name, str, List[str] or List[bytes]')
+        return Name(components)
+
+    def __iadd__(self, comp_s) -> 'Name':
         """Add Name components or a string component to the component list of the name"""
         if type(comp_s) is list:
             for c in comp_s:
-                self._components.append(c)
-            return self
+                if type(c) is str:
+                    self._components.append(c.encode('ascii'))
+                elif type(c) is bytes:
+                    self._components.append(c)
+                else:
+                    raise TypeError('Not a Name, str, List[str] or List[bytes]')
         elif type(comp_s) is str:
-            self._components.append(comp_s.encode('ascii'))
-            return self
+            o = Name(comp_s)
+            for c in o._components:
+                self._components.append(c)
+        elif isinstance(comp_s, Name):
+            for c in comp_s._components:
+                self._components.append(c)
+        else:
+            raise TypeError('Not a Name, str, List[str] or List[bytes]')
+        return self
 
     def __hash__(self) -> int:
         return self._components.__str__().__hash__()

--- a/PiCN/Packets/Name.py
+++ b/PiCN/Packets/Name.py
@@ -96,27 +96,6 @@ class Name(object):
             raise TypeError('Not a Name, str, List[str] or List[bytes]')
         return Name(components)
 
-    def __iadd__(self, comp_s) -> 'Name':
-        """Add Name components or a string component to the component list of the name"""
-        if type(comp_s) is list:
-            for c in comp_s:
-                if type(c) is str:
-                    self._components.append(c.encode('ascii'))
-                elif type(c) is bytes:
-                    self._components.append(c)
-                else:
-                    raise TypeError('Not a Name, str, List[str] or List[bytes]')
-        elif type(comp_s) is str:
-            o = Name(comp_s)
-            for c in o._components:
-                self._components.append(c)
-        elif isinstance(comp_s, Name):
-            for c in comp_s._components:
-                self._components.append(c)
-        else:
-            raise TypeError('Not a Name, str, List[str] or List[bytes]')
-        return self
-
     def __hash__(self) -> int:
         return self._components.__str__().__hash__()
 

--- a/PiCN/Packets/test/test_Name.py
+++ b/PiCN/Packets/test/test_Name.py
@@ -3,6 +3,7 @@ import unittest
 
 from PiCN.Packets import Name
 
+
 class TestContent(unittest.TestCase):
 
     def setUp(self):
@@ -22,3 +23,42 @@ class TestContent(unittest.TestCase):
         n1 = Name("/test/data")
         n2 = Name("/test/data1")
         self.assertNotEqual(n1, n2)
+
+    def test_constructor_str(self):
+        n = Name('/test/data')
+        self.assertEqual([b'test', b'data'], n._components)
+
+    def test_constructor_byteslist(self):
+        n = Name([b'test', b'data'])
+        self.assertEqual([b'test', b'data'], n._components)
+        self.assertEqual('/test/data', n.components_to_string())
+
+    def test_add_names(self):
+        n1 = Name('/test')
+        n2 = Name('/data')
+        n = n1 + n2
+        self.assertEqual([b'test', b'data'], n._components)
+        self.assertEqual('/test/data', n.components_to_string())
+
+    def test_add_str(self):
+        n1 = Name('/test')
+        n = n1 + '/data'
+        self.assertEqual([b'test', b'data'], n._components)
+        self.assertEqual('/test/data', n.components_to_string())
+
+    def test_add_list(self):
+        n1 = Name('/test')
+        n = n1 + [b'data']
+        self.assertEqual([b'test', b'data'], n._components)
+        self.assertEqual('/test/data', n.components_to_string())
+
+    def test_add_type_error(self):
+        n1 = Name('/test')
+        with self.assertRaises(TypeError):
+            n1 + 42
+
+    def test_add_inplace(self):
+        n = Name('/test')
+        n += '/data'
+        self.assertEqual([b'test', b'data'], n._components)
+        self.assertEqual('/test/data', n.components_to_string())


### PR DESCRIPTION
The method `__add__` of PiCN.Packets.Name acted in-place, which it should not do.

This patch implements out-of-place addition with increased functionality, and contains unit tests for using the `+` and `+=` operators together with Name objects .