### PR TITLE
Fixed wrong Name + str behavior

### DIFF
--- a/PiCN/Packets/Name.py
+++ b/PiCN/Packets/Name.py
@@ -86,9 +86,7 @@ class Name(object):
                 else:
                     raise TypeError('Not a Name, str, List[str] or List[bytes]')
         elif type(other) is str:
-            o = Name(other)
-            for comp in o._components:
-                components.append(comp)
+                components.append(other.encode('ascii'))
         elif isinstance(other, Name):
             for comp in other._components:
                 components.append(comp)

--- a/PiCN/Packets/test/test_Name.py
+++ b/PiCN/Packets/test/test_Name.py
@@ -42,7 +42,7 @@ class TestContent(unittest.TestCase):
 
     def test_add_str(self):
         n1 = Name('/test')
-        n = n1 + '/data'
+        n = n1 + 'data'
         self.assertEqual([b'test', b'data'], n._components)
         self.assertEqual('/test/data', n.components_to_string())
 
@@ -59,6 +59,6 @@ class TestContent(unittest.TestCase):
 
     def test_add_inplace(self):
         n = Name('/test')
-        n += '/data'
+        n += 'data'
         self.assertEqual([b'test', b'data'], n._components)
         self.assertEqual('/test/data', n.components_to_string())


### PR DESCRIPTION
This patch fixes the behavior of `__add__` in PiCN.Packets.Name introduced in #15 to match the previous behavior in the following scenario:

```python
n = Name('/data')
n += 'test'
print(n.components)  # Before #15: [b'data', b'test']
```
