### PR TITLE
Remove Multiprocessing.Manager from ICN Layer Datastructs

### DIFF
--- a/PiCN/Layers/ICNLayer/ContentStore/BaseContentStore.py
+++ b/PiCN/Layers/ICNLayer/ContentStore/BaseContentStore.py
@@ -49,22 +49,22 @@ class ContentStoreEntry(object):
 class BaseContentStore(object):
     """Abstract BaseContentStore for usage in BasicICNLayer"""
 
-    def __init__(self, manager: multiprocessing.Manager):
-        self._container: List[ContentStoreEntry] = manager.list()
+    def __init__(self):
+        self._container: List[ContentStoreEntry] = []
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def add_content_object(self, content: Content, static: bool=False):
         """check if there is already a content object stored, otherwise store it in the container"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def find_content_object(self, name: Name) -> ContentStoreEntry:
         """check if there is a matching content object"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def remove_content_object(self, name: Name):
         """Remove a content object from CS"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def update_timestamp(self, cs_entry: ContentStoreEntry):
         """Update Timestamp of a ContentStoreEntry"""
 

--- a/PiCN/Layers/ICNLayer/ContentStore/ContentStoreMemoryExact.py
+++ b/PiCN/Layers/ICNLayer/ContentStore/ContentStoreMemoryExact.py
@@ -9,8 +9,8 @@ from PiCN.Layers.ICNLayer.ContentStore import BaseContentStore, ContentStoreEntr
 class ContentStoreMemoryExact(BaseContentStore):
     """ A in memory Content Store using exact matching"""
 
-    def __init__(self, manager: multiprocessing.Manager):
-        BaseContentStore.__init__(self, manager)
+    def __init__(self):
+        BaseContentStore.__init__(self)
 
     def find_content_object(self, name: Name) -> ContentStoreEntry:
         for c in self._container:

--- a/PiCN/Layers/ICNLayer/ContentStore/test/test_ContentStoreMemoryExact.py
+++ b/PiCN/Layers/ICNLayer/ContentStore/test/test_ContentStoreMemoryExact.py
@@ -10,8 +10,7 @@ from PiCN.Packets import Content
 class test_ContentStoreMemoryExact(unittest.TestCase):
 
     def setUp(self):
-        self.manager = multiprocessing.Manager()
-        self.cs = ContentStoreMemoryExact(self.manager)
+        self.cs = ContentStoreMemoryExact()
 
     def tearDown(self):
         pass

--- a/PiCN/Layers/ICNLayer/ForwardingInformationBase/BaseForwardingInformationBase.py
+++ b/PiCN/Layers/ICNLayer/ForwardingInformationBase/BaseForwardingInformationBase.py
@@ -45,18 +45,18 @@ class ForwardingInformationBaseEntry(object):
 class BaseForwardingInformationBase(object):
     """Abstract BaseForwardingInformationBase for usage in BasicICNLayer"""
 
-    def __init__(self, manager: multiprocessing.Manager):
-        self._container: List[ForwardingInformationBaseEntry] = manager.list()
+    def __init__(self):
+        self._container: List[ForwardingInformationBaseEntry] = []
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def add_fib_entry(self, name: Name, fid: int, static: bool):
         """Add an Interest to the PIT"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def remove_fib_entry(self, name: Name):
         """Remove an entry from the PIT"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def find_fib_entry(self, name: Name, already_used: List[ForwardingInformationBaseEntry]) \
             ->ForwardingInformationBaseEntry:
         """Find an entry in the PIT"""

--- a/PiCN/Layers/ICNLayer/ForwardingInformationBase/ForwardingInformationBaseMemoryPrefix.py
+++ b/PiCN/Layers/ICNLayer/ForwardingInformationBase/ForwardingInformationBaseMemoryPrefix.py
@@ -10,8 +10,8 @@ from PiCN.Packets import Name, Interest
 
 class ForwardingInformationBaseMemoryPrefix(BaseForwardingInformationBase):
 
-    def __init__(self, manager: multiprocessing.Manager):
-        super().__init__(manager)
+    def __init__(self):
+        super().__init__()
 
     def find_fib_entry(self, name: Name, already_used: List[ForwardingInformationBaseEntry] = None) -> ForwardingInformationBaseEntry:
         components = name.components[:]

--- a/PiCN/Layers/ICNLayer/ForwardingInformationBase/test/test_ForwardingInformationBasePrefix.py
+++ b/PiCN/Layers/ICNLayer/ForwardingInformationBase/test/test_ForwardingInformationBasePrefix.py
@@ -12,7 +12,7 @@ class test_ForwardingInformationBaseMemoryPrefix(unittest.TestCase):
 
     def setUp(self):
         self.manager = multiprocessing.Manager()
-        self.fib = ForwardingInformationBaseMemoryPrefix(self.manager)
+        self.fib = ForwardingInformationBaseMemoryPrefix()
 
     def tearDown(self):
         pass

--- a/PiCN/Layers/ICNLayer/PendingInterestTable/BasePendingInterestTable.py
+++ b/PiCN/Layers/ICNLayer/PendingInterestTable/BasePendingInterestTable.py
@@ -88,8 +88,8 @@ class PendingInterestTableEntry(object):
 class BasePendingInterestTable(object):
     """Abstract BasePendingInterestaTable for usage in BasicICNLayer"""
 
-    def __init__(self, manager: multiprocessing.Manager):
-        self._container: List[PendingInterestTableEntry] = manager.list()
+    def __init__(self):
+        self._container: List[PendingInterestTableEntry] = []
 
     @abc.abstractclassmethod
     def add_pit_entry(self, name: Name, faceid: int, interest: Interest = None, local_app: bool = False):

--- a/PiCN/Layers/ICNLayer/PendingInterestTable/PendingInterestTableMemoryExact.py
+++ b/PiCN/Layers/ICNLayer/PendingInterestTable/PendingInterestTableMemoryExact.py
@@ -10,8 +10,8 @@ from PiCN.Packets import Interest, Name
 class PendingInterstTableMemoryExact(BasePendingInterestTable):
     """in-memory Pending Interest Table using exact prefix matching"""
 
-    def __init__(self, manager: multiprocessing.Manager) -> None:
-        super().__init__(manager)
+    def __init__(self) -> None:
+        super().__init__()
 
     def add_pit_entry(self, name, faceid: int, interest: Interest = None, local_app = False):
         for pit_entry in self._container:

--- a/PiCN/Layers/ICNLayer/PendingInterestTable/test/test_PendingInterestTableMemoryExact.py
+++ b/PiCN/Layers/ICNLayer/PendingInterestTable/test/test_PendingInterestTableMemoryExact.py
@@ -12,7 +12,7 @@ class test_PendingInterstTableMemoryExact(unittest.TestCase):
 
     def setUp(self):
         self.manager = multiprocessing.Manager()
-        self.pit: PendingInterstTableMemoryExact = PendingInterstTableMemoryExact(self.manager)
+        self.pit: PendingInterstTableMemoryExact = PendingInterstTableMemoryExact()
 
     def tearDown(self):
         pass

--- a/PiCN/Layers/ICNLayer/test/test_BasicICNLayer.py
+++ b/PiCN/Layers/ICNLayer/test/test_BasicICNLayer.py
@@ -19,7 +19,7 @@ class test_BasicICNLayer(unittest.TestCase):
         #setup icn_layer
         self.icn_layer = BasicICNLayer()
         self.manager = multiprocessing.Manager()
-        self.cs = ContentStoreMemoryExact(self.manager)
+        self.cs = ContentStoreMemoryExact()
         self.fib = ForwardingInformationBaseMemoryPrefix(self.manager)
         self.pit = PendingInterstTableMemoryExact(self.manager)
         self.icn_layer.cs = self.cs
@@ -151,7 +151,7 @@ class test_BasicICNLayer(unittest.TestCase):
 
         #add content
         content = Content("/test/data")
-        self.icn_layer.cs.add_content_object(content)
+        self.icn_layer.add_to_cs(content)
 
         #request content
         self.queue1_icn_routing_up.put([from_faceid, interest])
@@ -324,8 +324,8 @@ class test_BasicICNLayer(unittest.TestCase):
         name2 = Name("/data/test")
         content2 = Content(name2, "Goodbye")
 
-        self.cs.add_content_object(content1)
-        self.cs.add_content_object(content2, static=True)
+        self.icn_layer.add_to_cs(content1)
+        self.icn_layer.add_to_cs(content2, static=True)
 
         self.assertEqual(len(self.icn_layer.cs.container), 2)
         self.assertEqual(self.icn_layer.cs.container[0].content, content1)
@@ -511,7 +511,7 @@ class test_BasicICNLayer(unittest.TestCase):
         i = Interest(n)
         c = Content(n, "Hello World")
         self.icn_layer._fib.add_fib_entry(n, faceid, True)
-        self.icn_layer._cs.add_content_object(c)
+        self.icn_layer.add_to_cs(c)
         self.icn_layer.queue_from_lower.put([from_faceid, i])
         try:
             to_faceid, data = self.icn_layer.queue_to_lower.get(timeout=2.0)

--- a/PiCN/Layers/ICNLayer/test/test_BasicICNLayer.py
+++ b/PiCN/Layers/ICNLayer/test/test_BasicICNLayer.py
@@ -20,8 +20,8 @@ class test_BasicICNLayer(unittest.TestCase):
         self.icn_layer = BasicICNLayer()
         self.manager = multiprocessing.Manager()
         self.cs = ContentStoreMemoryExact()
-        self.fib = ForwardingInformationBaseMemoryPrefix(self.manager)
-        self.pit = PendingInterstTableMemoryExact(self.manager)
+        self.fib = ForwardingInformationBaseMemoryPrefix()
+        self.pit = PendingInterstTableMemoryExact()
         self.icn_layer.cs = self.cs
         self.icn_layer.fib = self.fib
         self.icn_layer.pit = self.pit
@@ -47,7 +47,7 @@ class test_BasicICNLayer(unittest.TestCase):
         #Add entry to the fib
         name = Name("/test/data")
         interest = Interest("/test/data")
-        self.icn_layer.fib.add_fib_entry(name, to_faceid, static=True)
+        self.icn_layer.add_to_fib(name, to_faceid, static=True)
 
         #forward entry
         self.queue1_icn_routing_up.put([from_faceid, interest])
@@ -79,7 +79,7 @@ class test_BasicICNLayer(unittest.TestCase):
         #Add entry to the fib
         name = Name("/test")
         interest = Interest("/test/data")
-        self.icn_layer.fib.add_fib_entry(name, to_faceid, static=True)
+        self.icn_layer.add_to_fib(name, to_faceid, static=True)
 
         #forward entry
         self.queue1_icn_routing_up.put([from_faceid, interest])
@@ -113,7 +113,7 @@ class test_BasicICNLayer(unittest.TestCase):
         name = Name("/test")
         interest1 = Interest("/test/data")
         interest2 = Interest("/test/data")
-        self.icn_layer.fib.add_fib_entry(name, to_faceid)
+        self.icn_layer.add_to_fib(name, to_faceid)
 
         # forward entry
         self.queue1_icn_routing_up.put([from_faceid1, interest1])
@@ -173,11 +173,11 @@ class test_BasicICNLayer(unittest.TestCase):
         from_faceid = 2
         interest = Interest("/test/data/bla")
         name = Name("/test/data")
-        self.icn_layer.fib.add_fib_entry(name, to_faceid, static=True)
+        self.icn_layer.add_to_fib(name, to_faceid, static=True)
 
         #add content
         content = Content("/test/data")
-        self.icn_layer.cs.add_content_object(content)
+        self.icn_layer.add_to_cs(content)
 
         #request content
         self.queue1_icn_routing_up.put([from_faceid, interest])
@@ -211,7 +211,7 @@ class test_BasicICNLayer(unittest.TestCase):
         name = Name("/test/data")
         content = Content("/test/data")
 
-        self.icn_layer.pit.add_pit_entry(name, from_faceid)
+        self.icn_layer.add_to_pit(name, from_faceid, None, None)
 
         self.queue1_icn_routing_up.put([content_in_faceid, content])
 
@@ -232,8 +232,8 @@ class test_BasicICNLayer(unittest.TestCase):
         name = Name("/test/data")
         content = Content("/test/data")
 
-        self.icn_layer.pit.add_pit_entry(name, from_faceid1)
-        self.icn_layer.pit.add_pit_entry(name, from_faceid2)
+        self.icn_layer.add_to_pit(name, from_faceid1, None, False)
+        self.icn_layer.add_to_pit(name, from_faceid2, None, False)
 
         self.queue1_icn_routing_up.put([content_in_faceid, content])
 
@@ -263,8 +263,8 @@ class test_BasicICNLayer(unittest.TestCase):
         name = Name("/test/data")
         interest = Interest(name)
 
-        self.icn_layer.fib.add_fib_entry(name, to_faceid)
-        self.icn_layer.pit.add_pit_entry(name, from_faceid1, interest)
+        self.icn_layer.add_to_fib(name, to_faceid)
+        self.icn_layer.add_to_pit(name, from_faceid1, interest, False)
         self.assertEqual(len(self.icn_layer.pit.container), 1)
         self.assertEqual(self.icn_layer.pit.container[0].name, name)
 
@@ -366,8 +366,8 @@ class test_BasicICNLayer(unittest.TestCase):
         self.icn_layer.start_process()
         faceid = 1
         n = Name("/test/data")
-        self.icn_layer._pit.add_pit_entry(n, faceid)
-        self.assertEqual(len(self.icn_layer._pit.container), 1)
+        self.icn_layer.add_to_pit(n, faceid, None, None)
+        self.assertEqual(len(self.icn_layer.pit.container), 1)
         c = Content(n, "HelloWorld")
         self.icn_layer.queue_from_higher.put([0, c])
         try:
@@ -401,8 +401,8 @@ class test_BasicICNLayer(unittest.TestCase):
         faceid = -1
         from_faceid = 1
         n = Name("/test/data")
-        self.icn_layer._pit.add_pit_entry(n, faceid, local_app=True)
-        self.assertEqual(len(self.icn_layer._pit.container), 1)
+        self.icn_layer.add_to_pit(n, faceid, interest=None, local_app=True)
+        self.assertEqual(len(self.icn_layer.pit.container), 1)
         c = Content(n, "HelloWorld")
         self.icn_layer.queue_from_lower.put([from_faceid, c])
         try:
@@ -422,7 +422,7 @@ class test_BasicICNLayer(unittest.TestCase):
         faceid = 1
         n = Name("/test/data")
         i = Interest(n)
-        self.icn_layer._fib.add_fib_entry(n, faceid, True)
+        self.icn_layer.add_to_fib(n, faceid, True)
         self.icn_layer.queue_from_higher.put([0, i])
         try:
             to_faceid, data = self.icn_layer.queue_to_lower.get(timeout=2.0)
@@ -430,8 +430,8 @@ class test_BasicICNLayer(unittest.TestCase):
             self.fail()
         self.assertEqual(to_faceid, faceid)
         self.assertEqual(i, data)
-        self.assertEqual(self.icn_layer._pit.container[0].interest, i)
-        self.assertTrue(self.icn_layer._pit.container[0].local_app[0])
+        self.assertEqual(self.icn_layer.pit.container[0].interest, i)
+        self.assertTrue(self.icn_layer.pit.container[0].local_app[0])
 
     def test_ICNLayer_interest_from_app_layer_pit(self):
         """Test sending and interest message from APP with a PIT entry --> interest not for higher layer"""
@@ -445,9 +445,9 @@ class test_BasicICNLayer(unittest.TestCase):
         from_faceid = 2
         n = Name("/test/data")
         i = Interest(n)
-        self.icn_layer._fib.add_fib_entry(n, faceid, True)
-        self.icn_layer._pit.add_pit_entry(n, from_faceid, i, local_app=False)
-        self.assertFalse(self.icn_layer._pit.container[0].local_app[0])
+        self.icn_layer.add_to_fib(n, faceid, True)
+        self.icn_layer.add_to_pit(n, from_faceid, i, local_app=False)
+        self.assertFalse(self.icn_layer.pit.container[0].local_app[0])
         self.icn_layer.queue_from_higher.put([0, i])
         try:
             to_faceid, data = self.icn_layer.queue_to_lower.get(timeout=2.0)
@@ -455,8 +455,8 @@ class test_BasicICNLayer(unittest.TestCase):
             self.fail()
         self.assertEqual(to_faceid, faceid)
         self.assertEqual(i, data)
-        self.assertEqual(self.icn_layer._pit.container[0].interest, i)
-        self.assertFalse(self.icn_layer._pit.container[0].local_app[0]) #Just forward, not from local app
+        self.assertEqual(self.icn_layer.pit.container[0].interest, i)
+        self.assertFalse(self.icn_layer.pit.container[0].local_app[0]) #Just forward, not from local app
 
     def test_ICNLayer_interest_to_app_layer_no_pit(self):
         """Test sending and interest message from APP with no PIT entry"""
@@ -470,14 +470,14 @@ class test_BasicICNLayer(unittest.TestCase):
         from_faceid = 2
         n = Name("/test/data")
         i = Interest(n)
-        self.icn_layer._fib.add_fib_entry(n, faceid, True)
+        self.icn_layer.add_to_fib(n, faceid, True)
         self.icn_layer.queue_from_lower.put([from_faceid, i])
         try:
             data = self.icn_layer.queue_to_higher.get(timeout=2.0)
         except:
             self.fail()
         self.assertEqual(data[1], i)
-        self.assertEqual(self.icn_layer._pit.container[0].interest, i)
+        self.assertEqual(self.icn_layer.pit.container[0].interest, i)
 
     def test_ICNLayer_interest_to_app_layer_pit(self):
         """Test sending and interest message from APP with a PIT entry"""
@@ -491,8 +491,8 @@ class test_BasicICNLayer(unittest.TestCase):
         from_faceid = 2
         n = Name("/test/data")
         i = Interest(n)
-        self.icn_layer._fib.add_fib_entry(n, faceid, True)
-        self.icn_layer._pit.add_pit_entry(n, from_faceid, i, local_app=False)
+        self.icn_layer.add_to_fib(n, faceid, True)
+        self.icn_layer.add_to_pit(n, from_faceid, i, local_app=False)
         self.icn_layer.queue_from_lower.put([from_faceid, i])
         time.sleep(1)
         self.assertTrue(self.icn_layer.queue_to_higher.empty()) #--> deduplication by pit entry
@@ -510,7 +510,7 @@ class test_BasicICNLayer(unittest.TestCase):
         n = Name("/test/data")
         i = Interest(n)
         c = Content(n, "Hello World")
-        self.icn_layer._fib.add_fib_entry(n, faceid, True)
+        self.icn_layer.add_to_fib(n, faceid, True)
         self.icn_layer.add_to_cs(c)
         self.icn_layer.queue_from_lower.put([from_faceid, i])
         try:
@@ -562,7 +562,7 @@ class test_BasicICNLayer(unittest.TestCase):
         i1 = Interest(n1)
         fid1 = 1
         nack1 = Nack(n1, NackReason.NO_ROUTE, interest=i1)
-        self.pit.add_pit_entry(n1, fid1, i1)
+        self.icn_layer.add_to_pit(n1, fid1, i1, False)
         self.icn_layer.queue_from_lower.put([2, nack1])
         try:
             data = self.icn_layer.queue_to_lower.get(timeout=2.0)
@@ -581,9 +581,9 @@ class test_BasicICNLayer(unittest.TestCase):
         to_fib2 = 3
         to_fib3 = 4
         nack1 = Nack(n1, NackReason.NO_ROUTE, interest=i1)
-        self.pit.add_pit_entry(n1, from_fid, i1)
-        self.fib.add_fib_entry(Name("/test"), to_fib2)
-        self.fib.add_fib_entry(Name("/test/data"), to_fib3)
+        self.icn_layer.add_to_pit(n1, from_fid, i1, None)
+        self.icn_layer.add_to_fib(Name("/test"), to_fib2)
+        self.icn_layer.add_to_fib(Name("/test/data"), to_fib3)
         self.icn_layer.queue_from_lower.put([to_fib1, nack1])
         try:
             data = self.icn_layer.queue_to_lower.get(timeout=2.0)

--- a/PiCN/Layers/NFNLayer/BasicNFNLayer.py
+++ b/PiCN/Layers/NFNLayer/BasicNFNLayer.py
@@ -23,12 +23,9 @@ class BasicNFNLayer(LayerProcess):
     """NFN Layer Implementation"""
 
     def __init__(self, manager: multiprocessing.Manager, data_structs: Dict,
-                 fib: BaseForwardingInformationBase, pit: BasePendingInterestTable,
                  executor: Dict[str, type(BaseNFNExecutor)], logger_name="NFN Layer", log_level=255):
         super().__init__(logger_name, log_level)
         self._data_structs = data_structs
-        self.fib = fib
-        self.pit = pit
         self._running_computations: Dict[int, NFNEvaluator] = {} # {} #computation id -> computation
         self._computation_request_table: Dict[Name, List[int]] = manager.dict()  # request(name) -> [computation id]
         self._pending_computations: multiprocessing.Queue[(Interest, bool)] = multiprocessing.Queue() # computations not started yet
@@ -243,7 +240,7 @@ class BasicNFNLayer(LayerProcess):
                 self.start_computation(interest[0], running_computations, interest[1])
 
     def start_computation(self, interest, running_computations, local: bool=False):
-        evaluator = self.nfn_evaluator_type(interest, self._data_structs, self.fib, self.pit,
+        evaluator = self.nfn_evaluator_type(interest, self._data_structs,
                                             self.rewrite_table, self.executor, local, self.logger.level)
         running_computations[self._next_computation_id] = evaluator
         running_computations[self._next_computation_id].start_process()

--- a/PiCN/Layers/NFNLayer/BasicNFNLayer.py
+++ b/PiCN/Layers/NFNLayer/BasicNFNLayer.py
@@ -22,11 +22,11 @@ from PiCN.Layers.NFNLayer.NFNEvaluator.NFNExecutor import BaseNFNExecutor
 class BasicNFNLayer(LayerProcess):
     """NFN Layer Implementation"""
 
-    def __init__(self, manager: multiprocessing.Manager, content_store: BaseContentStore,
+    def __init__(self, manager: multiprocessing.Manager, data_structs: Dict,
                  fib: BaseForwardingInformationBase, pit: BasePendingInterestTable,
                  executor: Dict[str, type(BaseNFNExecutor)], logger_name="NFN Layer", log_level=255):
         super().__init__(logger_name, log_level)
-        self.content_store = content_store
+        self._data_structs = data_structs
         self.fib = fib
         self.pit = pit
         self._running_computations: Dict[int, NFNEvaluator] = {} # {} #computation id -> computation
@@ -243,7 +243,7 @@ class BasicNFNLayer(LayerProcess):
                 self.start_computation(interest[0], running_computations, interest[1])
 
     def start_computation(self, interest, running_computations, local: bool=False):
-        evaluator = self.nfn_evaluator_type(interest, self.content_store, self.fib, self.pit,
+        evaluator = self.nfn_evaluator_type(interest, self._data_structs, self.fib, self.pit,
                                             self.rewrite_table, self.executor, local, self.logger.level)
         running_computations[self._next_computation_id] = evaluator
         running_computations[self._next_computation_id].start_process()

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNEvaluator.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNEvaluator.py
@@ -19,7 +19,7 @@ from PiCN.Packets import Content, Interest, Name, Nack, NackReason
 class NFNEvaluator(PiCNProcess):
     """NFN Dispatcher for PiCN"""
 
-    def __init__(self, interest: Interest, cs: BaseContentStore, fib: BaseForwardingInformationBase,
+    def __init__(self, interest: Interest, data_structs: dict, fib: BaseForwardingInformationBase,
                  pit: BasePendingInterestTable, rewrite_table: Dict[Interest, List[Interest]],
                  executor: Dict[str, type(BaseNFNExecutor)] = {}, local: bool=False, log_level: int = 255):
         super().__init__("NFNEvaluator", log_level)
@@ -32,7 +32,7 @@ class NFNEvaluator(PiCNProcess):
         self.request_table: List[Name] = []
         self.rewrite_table: Dict[Name, List[Name]] = rewrite_table #remapped name -> original names
 
-        self.cs: BaseContentStore = cs
+        self.data_structs: Dict = data_structs
         self.fib: BaseForwardingInformationBase = fib
         self.pit: BasePendingInterestTable = pit
 
@@ -65,7 +65,7 @@ class NFNEvaluator(PiCNProcess):
         name_str, prepended = self.parser.network_name_to_nfn_str(name)
         ast: AST = self.parser.parse(name_str)
         self.logger.info("Evaluating " + str(name))
-        self.optimizer = ToDataFirstOptimizer(prepended, self.cs, self.fib, self.pit)
+        self.optimizer = ToDataFirstOptimizer(prepended, self.data_structs, self.fib, self.pit)
         did_fwd = False
         if self.optimizer.compute_fwd(ast) and not self.force_compute_local:
             self.logger.info("FWD")

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNEvaluator.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNEvaluator.py
@@ -19,8 +19,7 @@ from PiCN.Packets import Content, Interest, Name, Nack, NackReason
 class NFNEvaluator(PiCNProcess):
     """NFN Dispatcher for PiCN"""
 
-    def __init__(self, interest: Interest, data_structs: dict, fib: BaseForwardingInformationBase,
-                 pit: BasePendingInterestTable, rewrite_table: Dict[Interest, List[Interest]],
+    def __init__(self, interest: Interest, data_structs: dict, rewrite_table: Dict[Interest, List[Interest]],
                  executor: Dict[str, type(BaseNFNExecutor)] = {}, local: bool=False, log_level: int = 255):
         super().__init__("NFNEvaluator", log_level)
         self.interest: Interest = interest
@@ -33,8 +32,6 @@ class NFNEvaluator(PiCNProcess):
         self.rewrite_table: Dict[Name, List[Name]] = rewrite_table #remapped name -> original names
 
         self.data_structs: Dict = data_structs
-        self.fib: BaseForwardingInformationBase = fib
-        self.pit: BasePendingInterestTable = pit
 
         self.parser: DefaultNFNParser = DefaultNFNParser()
         self.optimizer: BaseNFNOptimizer = None
@@ -65,7 +62,7 @@ class NFNEvaluator(PiCNProcess):
         name_str, prepended = self.parser.network_name_to_nfn_str(name)
         ast: AST = self.parser.parse(name_str)
         self.logger.info("Evaluating " + str(name))
-        self.optimizer = ToDataFirstOptimizer(prepended, self.data_structs, self.fib, self.pit)
+        self.optimizer = ToDataFirstOptimizer(prepended, self.data_structs)
         did_fwd = False
         if self.optimizer.compute_fwd(ast) and not self.force_compute_local:
             self.logger.info("FWD")

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/BaseNFNOptimizer.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/BaseNFNOptimizer.py
@@ -1,41 +1,41 @@
 """Base class for the NFN Optimizers"""
 
 import abc
+from typing import Dict
 
 from PiCN.Packets import Name
 from PiCN.Layers.NFNLayer.Parser import AST
-from PiCN.Layers.ICNLayer.ContentStore import BaseContentStore
 from PiCN.Layers.ICNLayer.ForwardingInformationBase import BaseForwardingInformationBase
 from PiCN.Layers.ICNLayer.PendingInterestTable import BasePendingInterestTable
 
 class BaseNFNOptimizer(object):
     """Base class for the NFN Optimizers"""
-    def __init__(self, prefix: Name, cs: BaseContentStore, fib: BaseForwardingInformationBase,
+    def __init__(self, prefix: Name, data_structs: Dict, fib: BaseForwardingInformationBase,
                  pit: BasePendingInterestTable):
         self.prefix: Name = prefix
-        self._cs: BaseContentStore = cs
+        self._data_structs = data_structs
         self._fib: BaseForwardingInformationBase = fib
         self._pit: BasePendingInterestTable = pit
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def compute_local(self, ast: AST) -> bool:
         """decide if the computation should be executed locally"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def compute_fwd(self, ast: AST) -> bool:
         """decide if the computation should be forwarded"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def rewrite(self, ast: AST):
         """rewrite the NFN interest and prepend a name"""
 
     @property
     def cs(self):
-        return self._cs
+        return self._data_structs.get('cs')
 
     @cs.setter
     def cs(self, cs):
-        self._cs = cs
+        self._data_structs['cs'] = cs
 
     @property
     def fib(self):

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/BaseNFNOptimizer.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/BaseNFNOptimizer.py
@@ -10,12 +10,9 @@ from PiCN.Layers.ICNLayer.PendingInterestTable import BasePendingInterestTable
 
 class BaseNFNOptimizer(object):
     """Base class for the NFN Optimizers"""
-    def __init__(self, prefix: Name, data_structs: Dict, fib: BaseForwardingInformationBase,
-                 pit: BasePendingInterestTable):
+    def __init__(self, prefix: Name, data_structs: Dict):
         self.prefix: Name = prefix
         self._data_structs = data_structs
-        self._fib: BaseForwardingInformationBase = fib
-        self._pit: BasePendingInterestTable = pit
 
     @abc.abstractmethod
     def compute_local(self, ast: AST) -> bool:
@@ -39,17 +36,17 @@ class BaseNFNOptimizer(object):
 
     @property
     def fib(self):
-        return self._fib
+        return self._data_structs.get('fib')
 
     @fib.setter
     def fib(self, fib):
-        self._fib = fib
+        self._data_structs['fib'] = fib
 
     @property
     def pit(self):
-        return self._pit
+        return self._data_structs.get('pit')
 
     @pit.setter
     def pit(self, pit):
-        self._pit = pit
+        self._data_structs['pit'] = pit
 

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/ToDataFirstOptimizer.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/ToDataFirstOptimizer.py
@@ -10,9 +10,8 @@ from PiCN.Layers.ICNLayer.PendingInterestTable import BasePendingInterestTable
 
 class ToDataFirstOptimizer(BaseNFNOptimizer):
 
-    def __init__(self, prefix: Name, data_structs: Dict, fib: BaseForwardingInformationBase,
-                 pit: BasePendingInterestTable) -> None:
-        super().__init__(prefix, data_structs, fib, pit)
+    def __init__(self, prefix: Name, data_structs: Dict) -> None:
+        super().__init__(prefix, data_structs)
 
     def compute_local(self, ast: AST) -> bool:
         if self.cs.find_content_object(self.prefix):

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/ToDataFirstOptimizer.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/ToDataFirstOptimizer.py
@@ -1,18 +1,18 @@
 """Simple NFN Optimizer, alsways forwarding towards data"""
 
+from typing import Dict
 
 from PiCN.Packets import Name
 from PiCN.Layers.NFNLayer.Parser.AST import *
 from PiCN.Layers.NFNLayer.NFNEvaluator.NFNOptimizer import BaseNFNOptimizer
-from PiCN.Layers.ICNLayer.ContentStore import BaseContentStore
 from PiCN.Layers.ICNLayer.ForwardingInformationBase import BaseForwardingInformationBase
 from PiCN.Layers.ICNLayer.PendingInterestTable import BasePendingInterestTable
 
 class ToDataFirstOptimizer(BaseNFNOptimizer):
 
-    def __init__(self, prefix: Name, cs: BaseContentStore, fib: BaseForwardingInformationBase,
+    def __init__(self, prefix: Name, data_structs: Dict, fib: BaseForwardingInformationBase,
                  pit: BasePendingInterestTable) -> None:
-        super().__init__(prefix, cs, fib, pit)
+        super().__init__(prefix, data_structs, fib, pit)
 
     def compute_local(self, ast: AST) -> bool:
         if self.cs.find_content_object(self.prefix):

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/test/test_ToDataFirstOptimizer.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/test/test_ToDataFirstOptimizer.py
@@ -17,7 +17,9 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
     def setUp(self):
         self.parser: DefaultNFNParser = DefaultNFNParser()
         self.manager = multiprocessing.Manager()
-        self.optimizer: ToDataFirstOptimizer = ToDataFirstOptimizer(None, ContentStoreMemoryExact(self.manager),
+        self.data_structs = self.manager.dict()
+        self.data_structs['cs'] = ContentStoreMemoryExact()
+        self.optimizer: ToDataFirstOptimizer = ToDataFirstOptimizer(None, self.data_structs,
                                                                     ForwardingInformationBaseMemoryPrefix(self.manager),
                                                                     None)
 
@@ -80,8 +82,10 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         workflow = "/func/f1(/test/data)"
         self.optimizer.fib.add_fib_entry(Name("/func"), 1, False)
         self.optimizer.prefix = Name("/func/f1")
-        self.optimizer.cs.add_content_object(
+        cs = self.optimizer.cs
+        cs.add_content_object(
             Content(Name("/func/f1"), "PYTHON\nf\ndef f():\n    return 'Hello World'"),True)
+        self.optimizer.cs = cs
         ast = self.parser.parse(workflow)
         self.assertFalse(self.optimizer.compute_fwd(ast))
         self.assertTrue(self.optimizer.compute_local(ast))

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/test/test_ToDataFirstOptimizer.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/NFNOptimizer/test/test_ToDataFirstOptimizer.py
@@ -19,9 +19,8 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         self.manager = multiprocessing.Manager()
         self.data_structs = self.manager.dict()
         self.data_structs['cs'] = ContentStoreMemoryExact()
-        self.optimizer: ToDataFirstOptimizer = ToDataFirstOptimizer(None, self.data_structs,
-                                                                    ForwardingInformationBaseMemoryPrefix(self.manager),
-                                                                    None)
+        self.data_structs['fib'] = ForwardingInformationBaseMemoryPrefix()
+        self.optimizer: ToDataFirstOptimizer = ToDataFirstOptimizer(None, self.data_structs)
 
     def tearDown(self):
         pass
@@ -42,7 +41,9 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name += "_()"
         cmp_name += "NFN"
         workflow = "/func/f1()"
-        self.optimizer.fib.add_fib_entry(Name("/func"), 1, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/func"), 1, False)
+        self.optimizer.fib = fib
         ast = self.parser.parse(workflow)
         self.assertTrue(self.optimizer.compute_fwd(ast))
         self.assertFalse(self.optimizer.compute_local(ast))
@@ -61,7 +62,9 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name += "_(/test/data)"
         cmp_name += "NFN"
         workflow = "/func/f1(/test/data)"
-        self.optimizer.fib.add_fib_entry(Name("/func"), 1, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/func"), 1, False)
+        self.optimizer.fib = fib
         ast = self.parser.parse(workflow)
         self.assertTrue(self.optimizer.compute_fwd(ast))
         self.assertFalse(self.optimizer.compute_local(ast))
@@ -80,7 +83,9 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name += "_(/test/data)"
         cmp_name += "NFN"
         workflow = "/func/f1(/test/data)"
-        self.optimizer.fib.add_fib_entry(Name("/func"), 1, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/func"), 1, False)
+        self.optimizer.fib = fib
         self.optimizer.prefix = Name("/func/f1")
         cs = self.optimizer.cs
         cs.add_content_object(
@@ -104,7 +109,9 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name._components.append("_(/test/data)")
         cmp_name._components.append("NFN")
         workflow = "/func/f1(/test/data)"
-        self.optimizer.fib.add_fib_entry(Name("/func"), 1, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/func"), 1, False)
+        self.optimizer.fib = fib
         self.optimizer.prefix = Name("/func/f1")
         ast = self.parser.parse(workflow)
         self.assertTrue(self.optimizer.compute_fwd(ast))
@@ -117,7 +124,9 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name += "/func/f1(_)"
         cmp_name += "NFN"
         workflow = "/func/f1(/test/data)"
-        self.optimizer.fib.add_fib_entry(Name("/test"), 1, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/test"), 1, False)
+        self.optimizer.fib = fib
         ast = self.parser.parse(workflow)
         self.assertTrue(self.optimizer.compute_fwd(ast))
         self.assertFalse(self.optimizer.compute_local(ast))
@@ -138,8 +147,10 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name2 += "_(/test/data)"
         cmp_name2 += "NFN"
         workflow = "/func/f1(/test/data)"
-        self.optimizer.fib.add_fib_entry(Name("/test"), 1, False)
-        self.optimizer.fib.add_fib_entry(Name("/func"), 2, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/test"), 1, False)
+        fib.add_fib_entry(Name("/func"), 2, False)
+        self.optimizer.fib = fib
         ast = self.parser.parse(workflow)
         self.assertTrue(self.optimizer.compute_fwd(ast))
         self.assertFalse(self.optimizer.compute_local(ast))
@@ -166,8 +177,10 @@ class test_ToDataFirstOptimizer(unittest.TestCase):
         cmp_name2 = cmp_name2 + "/func/f1(/test/data,_(2,/data/test))"
         cmp_name2 = cmp_name2 + "NFN"
         workflow = "/func/f1(/test/data,/lib/f2(2,/data/test))"
-        self.optimizer.fib.add_fib_entry(Name("/lib"), 1, False)
-        self.optimizer.fib.add_fib_entry(Name("/test"), 2, False)
+        fib = self.optimizer.fib
+        fib.add_fib_entry(Name("/lib"), 1, False)
+        fib.add_fib_entry(Name("/test"), 2, False)
+        self.optimizer.fib = fib
         ast = self.parser.parse(workflow)
         self.assertTrue(self.optimizer.compute_fwd(ast))
         self.assertFalse(self.optimizer.compute_local(ast))

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/test/test_NFNEvaluator.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/test/test_NFNEvaluator.py
@@ -19,12 +19,12 @@ class testNFNEvaluator(unittest.TestCase):
         self.manager: multiprocessing.Manager = multiprocessing.Manager()
         self.data_structs = self.manager.dict()
         self.data_structs['cs'] = ContentStoreMemoryExact()
-        self.fib: ForwardingInformationBaseMemoryPrefix = ForwardingInformationBaseMemoryPrefix(self.manager)
-        self.pit: PendingInterstTableMemoryExact = PendingInterstTableMemoryExact(self.manager)
-        self.optimizer = ToDataFirstOptimizer(None, self.data_structs, self.fib, self.pit)
+        self.data_structs['fib'] = ForwardingInformationBaseMemoryPrefix()
+        self.data_structs['pit'] = PendingInterstTableMemoryExact()
+        self.optimizer = ToDataFirstOptimizer(None, self.data_structs)
         self.executor = NFNPythonExecutor
         self.rewrite_table = self.manager.dict()
-        self.evaluator = NFNEvaluator(None, self.data_structs, self.fib, self.pit, self.rewrite_table)
+        self.evaluator = NFNEvaluator(None, self.data_structs, self.rewrite_table)
         self.evaluator.executor["PYTHON"] = self.executor
         pass
 
@@ -177,7 +177,9 @@ def f(a, b):
 
     def test_fwd_multiple_params(self):
         """Test fwd a function with multiple data as parameter"""
-        self.evaluator.fib.add_fib_entry(Name("/test"), 0, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 0, True)
+        self.data_structs['fib'] = fib
         fwdname1 = Name("/test/data1")
         fwdname1 += "/func/f1(_,/test/data2)"
         fwdname1 += "NFN"

--- a/PiCN/Layers/NFNLayer/NFNEvaluator/test/test_NFNEvaluator.py
+++ b/PiCN/Layers/NFNLayer/NFNEvaluator/test/test_NFNEvaluator.py
@@ -17,13 +17,14 @@ class testNFNEvaluator(unittest.TestCase):
 
     def setUp(self):
         self.manager: multiprocessing.Manager = multiprocessing.Manager()
-        self.cs: ContentStoreMemoryExact = ContentStoreMemoryExact(self.manager)
+        self.data_structs = self.manager.dict()
+        self.data_structs['cs'] = ContentStoreMemoryExact()
         self.fib: ForwardingInformationBaseMemoryPrefix = ForwardingInformationBaseMemoryPrefix(self.manager)
         self.pit: PendingInterstTableMemoryExact = PendingInterstTableMemoryExact(self.manager)
-        self.optimizer = ToDataFirstOptimizer(None, self.cs, self.fib, self.pit)
+        self.optimizer = ToDataFirstOptimizer(None, self.data_structs, self.fib, self.pit)
         self.executor = NFNPythonExecutor
         self.rewrite_table = self.manager.dict()
-        self.evaluator = NFNEvaluator(None, self.cs, self.fib, self.pit, self.rewrite_table)
+        self.evaluator = NFNEvaluator(None, self.data_structs, self.fib, self.pit, self.rewrite_table)
         self.evaluator.executor["PYTHON"] = self.executor
         pass
 

--- a/PiCN/Layers/NFNLayer/test/test_BasicNFNLayer.py
+++ b/PiCN/Layers/NFNLayer/test/test_BasicNFNLayer.py
@@ -18,10 +18,10 @@ class test_BasicNFNLayer(unittest.TestCase):
         manager = multiprocessing.Manager()
         self.data_structs = manager.dict()
         self.data_structs['cs'] = ContentStoreMemoryExact()
-        self.fib = ForwardingInformationBaseMemoryPrefix(manager)
-        self.pit = PendingInterstTableMemoryExact(manager)
+        self.data_structs['fib'] = ForwardingInformationBaseMemoryPrefix()
+        self.data_structs['pit'] = PendingInterstTableMemoryExact()
         self.executor = {"PYTHON": NFNPythonExecutor}
-        self.nfnLayer: BasicNFNLayer = BasicNFNLayer(manager, self.data_structs, self.fib, self.pit, self.executor)
+        self.nfnLayer: BasicNFNLayer = BasicNFNLayer(manager, self.data_structs, self.executor)
         self.nfnLayer.queue_from_lower = multiprocessing.Queue()
         self.nfnLayer.queue_to_lower = multiprocessing.Queue()
 
@@ -61,7 +61,9 @@ class test_BasicNFNLayer(unittest.TestCase):
 
     def test_fwd_computation(self):
         """Test forwarding of a computation"""
-        self.fib.add_fib_entry(Name("/test"), 1, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 1, True)
+        self.data_structs['fib'] = fib
         self.nfnLayer.start_process()
         cid = 1
         name = Name("/test/data")
@@ -78,7 +80,9 @@ class test_BasicNFNLayer(unittest.TestCase):
 
     def test_fwd_computation_back(self):
         """Test forwarding of a computation sending data back"""
-        self.fib.add_fib_entry(Name("/test"), 1, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 1, True)
+        self.data_structs['fib'] = fib
         self.nfnLayer.start_process()
         cid = 1
         name = Name("/test/data")
@@ -99,7 +103,9 @@ class test_BasicNFNLayer(unittest.TestCase):
 
     def test_fwd_computation_change_name(self):
         """Test rewriting and forwarding of a computation"""
-        self.fib.add_fib_entry(Name("/test"), 1, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 1, True)
+        self.data_structs['fib'] = fib
         self.nfnLayer.start_process()
         cid = 1
         name = Name("/func/f1")
@@ -118,7 +124,9 @@ class test_BasicNFNLayer(unittest.TestCase):
 
     def test_fwd_computation_change_name_map_back(self):
         """Test rewriting and forwarding of a computation, map back"""
-        self.fib.add_fib_entry(Name("/test"), 1, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 1, True)
+        self.data_structs['fib'] = fib
         self.nfnLayer.start_process()
         cid = 1
         name = Name("/func/f1")
@@ -277,7 +285,9 @@ def f():
 
     def test_fwd_computation_nack_stop_fwd_nack(self):
         """Test forwarding of a computation and stop computation"""
-        self.fib.add_fib_entry(Name("/test"), 1, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 1, True)
+        self.data_structs['fib'] = fib
         self.nfnLayer.start_process()
         cid = 1
         name = Name("/test/data")
@@ -307,8 +317,10 @@ def f():
 
     def test_fwd_computation_nack_second_path(self):
         """Test forwarding of a computation and applying second rule"""
-        self.fib.add_fib_entry(Name("/test"), 1, True)
-        self.fib.add_fib_entry(Name("/func"), 2, True)
+        fib = self.data_structs.get('fib')
+        fib.add_fib_entry(Name("/test"), 1, True)
+        fib.add_fib_entry(Name("/func"), 2, True)
+        self.data_structs['fib'] = fib
         self.nfnLayer.start_process()
         cid = 1
         name = Name("/test/data")

--- a/PiCN/Layers/NFNLayer/test/test_BasicNFNLayer.py
+++ b/PiCN/Layers/NFNLayer/test/test_BasicNFNLayer.py
@@ -15,12 +15,13 @@ class test_BasicNFNLayer(unittest.TestCase):
     """Test the BasicNFNLayer"""
 
     def setUp(self):
-        self.manager = multiprocessing.Manager()
-        self.cs = ContentStoreMemoryExact(self.manager)
-        self.fib = ForwardingInformationBaseMemoryPrefix(self.manager)
-        self.pit = PendingInterstTableMemoryExact(self.manager)
+        manager = multiprocessing.Manager()
+        self.data_structs = manager.dict()
+        self.data_structs['cs'] = ContentStoreMemoryExact()
+        self.fib = ForwardingInformationBaseMemoryPrefix(manager)
+        self.pit = PendingInterstTableMemoryExact(manager)
         self.executor = {"PYTHON": NFNPythonExecutor}
-        self.nfnLayer: BasicNFNLayer = BasicNFNLayer(self.manager, self.cs, self.fib, self.pit, self.executor)
+        self.nfnLayer: BasicNFNLayer = BasicNFNLayer(manager, self.data_structs, self.fib, self.pit, self.executor)
         self.nfnLayer.queue_from_lower = multiprocessing.Queue()
         self.nfnLayer.queue_to_lower = multiprocessing.Queue()
 

--- a/PiCN/Mgmt/Mgmt.py
+++ b/PiCN/Mgmt/Mgmt.py
@@ -5,6 +5,7 @@ import os
 import select
 import socket
 import time
+from typing import Dict
 
 from PiCN.Layers.ICNLayer.ContentStore import BaseContentStore
 from PiCN.Layers.ICNLayer.ForwardingInformationBase import BaseForwardingInformationBase
@@ -18,10 +19,10 @@ from PiCN.Processes import PiCNProcess
 class Mgmt(PiCNProcess):
     """Mgmt System for PiCN"""
 
-    def __init__(self, cs: BaseContentStore, fib: BaseForwardingInformationBase, pit: BasePendingInterestTable,
+    def __init__(self, data_structs: Dict, fib: BaseForwardingInformationBase, pit: BasePendingInterestTable,
                  linklayer: LayerProcess, port: int, shutdown = None, repo_prfx: str=None, repo_path: str=None, log_level=255):
         super().__init__("MgmtSys", log_level)
-        self._cs: BaseContentStore = cs
+        self._data_structs: Dict = data_structs
         self._fib: BaseForwardingInformationBase = fib
         self._pit: BasePendingInterestTable = pit
         self._linklayer = linklayer
@@ -98,7 +99,7 @@ class Mgmt(PiCNProcess):
             return
 
     def icnl_mgmt(self, command, params, replysock):
-        if(self._cs == None or self._fib == None or self._pit == None):
+        if(self._data_structs.get('cs') == None or self._fib == None or self._pit == None):
             reply = "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n Not a Forwarder OK\r\n"
             replysock.send(reply.encode())
         # newface expects /linklayer/newface/ip:port
@@ -117,7 +118,9 @@ class Mgmt(PiCNProcess):
             prefix = prefix.replace("%2F", "/")
             name = Name(prefix)
             content = Content(name, content)
-            self._cs.add_content_object(content, static=True)
+            cs = self._data_structs.get('cs')
+            cs.add_content_object(content, static=True)
+            self._data_structs['cs'] = cs
             reply = "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newcontent OK\r\n"
             replysock.send(reply.encode())
             self.logger.info("New content added " + prefix + "|" + content.content)

--- a/PiCN/Mgmt/test/test_Mgmt.py
+++ b/PiCN/Mgmt/test/test_Mgmt.py
@@ -25,11 +25,12 @@ class test_Mgmt(unittest.TestCase):
         self.q1 = multiprocessing.Queue()
         self.linklayer.queue_from_higher = self.q1
 
-        self.cs = ContentStoreMemoryExact(self.manager)
+        self._data_structs = self.manager.dict()
+        self._data_structs['cs'] = ContentStoreMemoryExact()
         self.fib = ForwardingInformationBaseMemoryPrefix(self.manager)
         self.pit = PendingInterstTableMemoryExact(self.manager)
 
-        self.mgmt = Mgmt(self.cs, self.fib, self.pit, self.linklayer, self.linklayerport)
+        self.mgmt = Mgmt(self._data_structs, self.fib, self.pit, self.linklayer, self.linklayerport)
         self.testMgmtSock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.testMgmtSock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.testMgmtSock3 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -147,8 +148,9 @@ class test_Mgmt(unittest.TestCase):
         self.assertEqual(data.decode(),
                          "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newcontent OK\r\n")
 
-        self.assertEqual(self.cs.find_content_object(Name("/test/data")).content.content, "HelloWorld")
-        self.assertEqual(self.cs.find_content_object(Name("/data/test")).content.content, "GoodBye")
+        cs = self._data_structs.get('cs')
+        self.assertEqual(cs.find_content_object(Name("/test/data")).content.content, "HelloWorld")
+        self.assertEqual(cs.find_content_object(Name("/data/test")).content.content, "GoodBye")
 
 
     def test_add_face_mgmt_client(self):
@@ -168,7 +170,7 @@ class test_Mgmt(unittest.TestCase):
         self.mgmt.start_process()
 
         data = self.mgmt_client.add_forwarding_rule(Name("/test/data"), 2)
-        self.assertEqual(data, "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:2\r\n")
+        self.assertEqual("HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:2\r\n", data)
 
         time.sleep(1)
         data = self.mgmt_client.add_forwarding_rule(Name("/data/test"), 3)
@@ -189,8 +191,9 @@ class test_Mgmt(unittest.TestCase):
         data = self.mgmt_client.add_new_content(Name("/data/test"), "GoodBye")
         self.assertEqual(data, "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newcontent OK\r\n")
 
-        self.assertEqual(self.cs.find_content_object(Name("/test/data")).content.content, "HelloWorld")
-        self.assertEqual(self.cs.find_content_object(Name("/data/test")).content.content, "GoodBye")
+        cs = self._data_structs.get('cs')
+        self.assertEqual(cs.find_content_object(Name("/test/data")).content.content, "HelloWorld")
+        self.assertEqual(cs.find_content_object(Name("/data/test")).content.content, "GoodBye")
 
     def test_mgmt_shutdown_mgmt_client(self):
         """Test adding content"""

--- a/PiCN/Mgmt/test/test_Mgmt.py
+++ b/PiCN/Mgmt/test/test_Mgmt.py
@@ -27,10 +27,10 @@ class test_Mgmt(unittest.TestCase):
 
         self._data_structs = self.manager.dict()
         self._data_structs['cs'] = ContentStoreMemoryExact()
-        self.fib = ForwardingInformationBaseMemoryPrefix(self.manager)
-        self.pit = PendingInterstTableMemoryExact(self.manager)
+        self._data_structs['fib'] = ForwardingInformationBaseMemoryPrefix()
+        self._data_structs['pit'] = PendingInterstTableMemoryExact()
 
-        self.mgmt = Mgmt(self._data_structs, self.fib, self.pit, self.linklayer, self.linklayerport)
+        self.mgmt = Mgmt(self._data_structs, self.linklayer, self.linklayerport)
         self.testMgmtSock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.testMgmtSock2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.testMgmtSock3 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -123,8 +123,8 @@ class test_Mgmt(unittest.TestCase):
         self.assertEqual(data.decode(),
                          "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:3\r\n")
 
-        self.assertEqual(self.fib.find_fib_entry(Name("/test/data")).faceid, 2)
-        self.assertEqual(self.fib.find_fib_entry(Name("/data/test")).faceid, 3)
+        self.assertEqual(self._data_structs.get('fib').find_fib_entry(Name("/test/data")).faceid, 2)
+        self.assertEqual(self._data_structs.get('fib').find_fib_entry(Name("/data/test")).faceid, 3)
 
     def test_mgmt_add_content(self):
         """Test adding content"""
@@ -176,8 +176,8 @@ class test_Mgmt(unittest.TestCase):
         data = self.mgmt_client.add_forwarding_rule(Name("/data/test"), 3)
         self.assertEqual(data, "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:3\r\n")
 
-        self.assertEqual(self.fib.find_fib_entry(Name("/test/data")).faceid, 2)
-        self.assertEqual(self.fib.find_fib_entry(Name("/data/test")).faceid, 3)
+        self.assertEqual(self._data_structs.get('fib').find_fib_entry(Name("/test/data")).faceid, 2)
+        self.assertEqual(self._data_structs.get('fib').find_fib_entry(Name("/data/test")).faceid, 3)
 
     def test_mgmt_add_content_mgmt_client(self):
         """Test adding content using MgmtClient"""

--- a/PiCN/ProgramLibs/Fetch/test/test_FetchNFN.py
+++ b/PiCN/ProgramLibs/Fetch/test/test_FetchNFN.py
@@ -83,7 +83,7 @@ class cases_FetchNFN(object):
         self.add_face_and_forwadingrule()
         fetch_name = "/test/data/d1"
         try:
-            content = self.fetch.fetch_data(fetch_name, timeout=10.0)
+            content = self.fetch.fetch_data(fetch_name, timeout=15.0)
         except:
             self.fail
         self.assertEqual(self.data1, content)
@@ -96,7 +96,7 @@ class cases_FetchNFN(object):
         time.sleep(0.1)
         self.add_face_and_forwadingrule()
         fetch_name = "/test/data/d3"
-        content = self.fetch.fetch_data(fetch_name, timeout=10.0)
+        content = self.fetch.fetch_data(fetch_name, timeout=15.0)
         self.assertEqual(self.data3, content)
 
     def test_compute_on_single_data_over_forwarder(self):
@@ -112,7 +112,7 @@ class cases_FetchNFN(object):
         fetch_name += "_(/test/data/d1)"
         fetch_name += "NFN"
         try:
-            content = self.fetch.fetch_data(fetch_name, timeout=10.0)
+            content = self.fetch.fetch_data(fetch_name, timeout=15.0)
         except:
             self.fail()
         self.assertEqual(self.data1.upper(), content)

--- a/PiCN/ProgramLibs/ICNDataRepository/ICNDataRepository.py
+++ b/PiCN/ProgramLibs/ICNDataRepository/ICNDataRepository.py
@@ -53,7 +53,7 @@ class ICNDataRepository(object):
         ])
 
         # mgmt
-        self.mgmt = Mgmt(None, None, None, self.linklayer, self.linklayer.get_port(),
+        self.mgmt = Mgmt(None, self.linklayer, self.linklayer.get_port(),
                          self.start_repo, repo_path=foldername,
                          repo_prfx=prefix, log_level=log_level)
 

--- a/PiCN/ProgramLibs/ICNForwarder/ICNForwarder.py
+++ b/PiCN/ProgramLibs/ICNForwarder/ICNForwarder.py
@@ -38,8 +38,8 @@ class ICNForwarder(object):
         manager = multiprocessing.Manager()
         self.data_structs = manager.dict()
         self.data_structs['cs'] = ContentStoreMemoryExact()
-        self.fib = ForwardingInformationBaseMemoryPrefix(manager)
-        self.pit = PendingInterstTableMemoryExact(manager)
+        self.data_structs['fib'] = ForwardingInformationBaseMemoryPrefix()
+        self.data_structs['pit'] = PendingInterstTableMemoryExact()
 
         self.lstack: LayerStack = LayerStack([
             self.icnlayer,
@@ -48,14 +48,12 @@ class ICNForwarder(object):
         ])
 
         self.icnlayer._data_structs = self.data_structs
-        self.icnlayer.fib = self.fib
-        self.icnlayer.pit = self.pit
 
         # routing
         self.routing = BasicRouting(self.icnlayer.pit, None, log_level=log_level) #TODO NOT IMPLEMENTED YET
 
         # mgmt
-        self.mgmt = Mgmt(self.data_structs, self.fib, self.pit, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
+        self.mgmt = Mgmt(self.data_structs, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
                          log_level=log_level)
 
     def start_forwarder(self):

--- a/PiCN/ProgramLibs/ICNForwarder/ICNForwarder.py
+++ b/PiCN/ProgramLibs/ICNForwarder/ICNForwarder.py
@@ -36,7 +36,8 @@ class ICNForwarder(object):
 
         # setup data structures
         manager = multiprocessing.Manager()
-        self.cs = ContentStoreMemoryExact(manager)
+        self.data_structs = manager.dict()
+        self.data_structs['cs'] = ContentStoreMemoryExact()
         self.fib = ForwardingInformationBaseMemoryPrefix(manager)
         self.pit = PendingInterstTableMemoryExact(manager)
 
@@ -46,7 +47,7 @@ class ICNForwarder(object):
             self.linklayer
         ])
 
-        self.icnlayer.cs = self.cs
+        self.icnlayer._data_structs = self.data_structs
         self.icnlayer.fib = self.fib
         self.icnlayer.pit = self.pit
 
@@ -54,7 +55,7 @@ class ICNForwarder(object):
         self.routing = BasicRouting(self.icnlayer.pit, None, log_level=log_level) #TODO NOT IMPLEMENTED YET
 
         # mgmt
-        self.mgmt = Mgmt(self.cs, self.fib, self.pit, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
+        self.mgmt = Mgmt(self.data_structs, self.fib, self.pit, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
                          log_level=log_level)
 
     def start_forwarder(self):

--- a/PiCN/ProgramLibs/ICNForwarder/test/test_ICNForwarder.py
+++ b/PiCN/ProgramLibs/ICNForwarder/test/test_ICNForwarder.py
@@ -90,7 +90,7 @@ class cases_ICNForwarder(object):
         testMgmtSock2.close()
         self.assertEqual(data.decode(),
                          "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:0\r\n")
-        self.assertEqual(self.forwarder1.fib.find_fib_entry(Name("/test/data")).faceid, 0)
+        self.assertEqual(self.forwarder1.icnlayer.fib.find_fib_entry(Name("/test/data")).faceid, 0)
 
         # new content
         testMgmtSock3 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -118,7 +118,7 @@ class cases_ICNForwarder(object):
         content = self.encoder.decode(encoded_content)
         self.assertEqual(content, test_content)
         time.sleep(2)
-        self.assertEqual(len(self.forwarder1.pit.container), 0)
+        self.assertEqual(len(self.forwarder1.icnlayer.pit.container), 0)
 
 
 

--- a/PiCN/ProgramLibs/ICNForwarder/test/test_ICNForwarder.py
+++ b/PiCN/ProgramLibs/ICNForwarder/test/test_ICNForwarder.py
@@ -52,7 +52,8 @@ class cases_ICNForwarder(object):
         #create test content
         name = Name("/test/data/object")
         test_content = Content(name, content="HelloWorld")
-        self.assertEqual(self.forwarder1.cs.find_content_object(name).content, test_content)
+        cs_fwd1 = self.forwarder1.data_structs.get('cs')
+        self.assertEqual(cs_fwd1.find_content_object(name).content, test_content)
 
         #create interest
         interest = Interest("/test/data/object")
@@ -103,7 +104,8 @@ class cases_ICNForwarder(object):
         #create test content
         name = Name("/test/data/object")
         test_content = Content(name, content="HelloWorld")
-        self.assertEqual(self.forwarder2.cs.find_content_object(name).content, test_content)
+        cs_fwd2 = self.forwarder2.data_structs.get('cs')
+        self.assertEqual(cs_fwd2.find_content_object(name).content, test_content)
 
         #create interest
         interest = Interest("/test/data/object")

--- a/PiCN/ProgramLibs/NFNForwarder/NFNForwarder.py
+++ b/PiCN/ProgramLibs/NFNForwarder/NFNForwarder.py
@@ -41,11 +41,12 @@ class NFNForwarder(object):
 
         # setup data structures
         manager = multiprocessing.Manager()
-        self.cs = ContentStoreMemoryExact(manager)
+        self.data_structs = manager.dict()
+        self.data_structs['cs'] = ContentStoreMemoryExact()
         self.fib = ForwardingInformationBaseMemoryPrefix(manager)
         self.pit = PendingInterstTableMemoryExact(manager)
 
-        self.icnlayer.cs = self.cs
+        self.icnlayer._data_structs = self.data_structs
         self.icnlayer.fib = self.fib
         self.icnlayer.pit = self.pit
 
@@ -57,7 +58,7 @@ class NFNForwarder(object):
         # setup nfn
         self.icnlayer._interest_to_app = True
         self.executors = {"PYTHON": NFNPythonExecutor}
-        self.nfnlayer = BasicNFNLayer(manager, self.cs, self.fib, self.pit, self.executors,
+        self.nfnlayer = BasicNFNLayer(manager, self.icnlayer._data_structs, self.fib, self.pit, self.executors,
                                       log_level=log_level)
 
         self.lstack: LayerStack = LayerStack([
@@ -72,7 +73,7 @@ class NFNForwarder(object):
         self.routing = BasicRouting(self.icnlayer.pit, None, log_level=log_level)  # TODO NOT IMPLEMENTED YET
 
         # mgmt
-        self.mgmt = Mgmt(self.cs, self.fib, self.pit, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
+        self.mgmt = Mgmt(self.data_structs, self.fib, self.pit, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
                          log_level=log_level)
 
     def start_forwarder(self):

--- a/PiCN/ProgramLibs/NFNForwarder/NFNForwarder.py
+++ b/PiCN/ProgramLibs/NFNForwarder/NFNForwarder.py
@@ -43,12 +43,10 @@ class NFNForwarder(object):
         manager = multiprocessing.Manager()
         self.data_structs = manager.dict()
         self.data_structs['cs'] = ContentStoreMemoryExact()
-        self.fib = ForwardingInformationBaseMemoryPrefix(manager)
-        self.pit = PendingInterstTableMemoryExact(manager)
+        self.data_structs['fib'] = ForwardingInformationBaseMemoryPrefix()
+        self.data_structs['pit'] = PendingInterstTableMemoryExact()
 
         self.icnlayer._data_structs = self.data_structs
-        self.icnlayer.fib = self.fib
-        self.icnlayer.pit = self.pit
 
         self.chunkifier = SimpleContentChunkifyer()
 
@@ -58,7 +56,7 @@ class NFNForwarder(object):
         # setup nfn
         self.icnlayer._interest_to_app = True
         self.executors = {"PYTHON": NFNPythonExecutor}
-        self.nfnlayer = BasicNFNLayer(manager, self.icnlayer._data_structs, self.fib, self.pit, self.executors,
+        self.nfnlayer = BasicNFNLayer(manager, self.icnlayer._data_structs, self.executors,
                                       log_level=log_level)
 
         self.lstack: LayerStack = LayerStack([
@@ -73,7 +71,7 @@ class NFNForwarder(object):
         self.routing = BasicRouting(self.icnlayer.pit, None, log_level=log_level)  # TODO NOT IMPLEMENTED YET
 
         # mgmt
-        self.mgmt = Mgmt(self.data_structs, self.fib, self.pit, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
+        self.mgmt = Mgmt(self.data_structs, self.linklayer, self.linklayer.get_port(), self.stop_forwarder,
                          log_level=log_level)
 
     def start_forwarder(self):

--- a/PiCN/ProgramLibs/NFNForwarder/test/test_NFNForwarder.py
+++ b/PiCN/ProgramLibs/NFNForwarder/test/test_NFNForwarder.py
@@ -90,7 +90,7 @@ class cases_NFNForwarder(object):
         testMgmtSock2.close()
         self.assertEqual(data.decode(),
                          "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:0\r\n")
-        self.assertEqual(self.forwarder1.fib.find_fib_entry(Name("/test/data")).faceid, 0)
+        self.assertEqual(self.forwarder1.icnlayer.fib.find_fib_entry(Name("/test/data")).faceid, 0)
 
         # new content
         testMgmtSock3 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -118,7 +118,7 @@ class cases_NFNForwarder(object):
         content = self.encoder.decode(encoded_content)
         self.assertEqual(content, test_content)
         time.sleep(4)
-        self.assertEqual(len(self.forwarder1.pit.container), 0)
+        self.assertEqual(len(self.forwarder1.icnlayer.pit.container), 0)
 
     def test_NFNForwarder_simple_compute_two_nodes(self):
         """Test a simple forwarding scenario with one additional node forwarding the data"""
@@ -145,7 +145,7 @@ class cases_NFNForwarder(object):
         testMgmtSock2.close()
         self.assertEqual(data.decode(),
                          "HTTP/1.1 200 OK \r\n Content-Type: text/html \r\n\r\n newforwardingrule OK:0\r\n")
-        self.assertEqual(0, self.forwarder1.fib.find_fib_entry(Name("/lib/func")).faceid)
+        self.assertEqual(0, self.forwarder1.icnlayer.fib.find_fib_entry(Name("/lib/func")).faceid)
 
         #add function
         testMgmtSock3 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -169,7 +169,7 @@ class cases_NFNForwarder(object):
         self.assertEqual("Hello World", content.content)
         self.assertEqual(name, content.name)
         time.sleep(2)
-        self.assertEqual(len(self.forwarder1.pit.container), 0)
+        self.assertEqual(len(self.forwarder1.icnlayer.pit.container), 0)
 
     def test_NFNForwarder_compute_param_two_nodes(self):
         """Test a simple forwarding scenario with one additional node forwarding the data"""
@@ -182,8 +182,8 @@ class cases_NFNForwarder(object):
         fid2 = self.forwarder2.linklayer.get_or_create_fid(("127.0.0.1", self.forwarder1_port), True)
 
         # register prefixes
-        self.forwarder1.fib.add_fib_entry(Name("/lib/func"), fid1, True)
-        self.forwarder2.fib.add_fib_entry(Name("/test"), fid2, True)
+        self.forwarder1.icnlayer.add_to_fib(Name("/lib/func"), fid1, True)
+        self.forwarder2.icnlayer.add_to_fib(Name("/test"), fid2, True)
 
         # add function
         testMgmtSock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -218,7 +218,7 @@ class cases_NFNForwarder(object):
         content: Content = self.encoder.decode(encoded_content)
         self.assertEqual("HELLOWORLD", content.content)
         self.assertEqual(name, content.name)
-        self.assertEqual(len(self.forwarder1.pit.container), 0)
+        self.assertEqual(len(self.forwarder1.icnlayer.pit.container), 0)
 
     def test_NFNForwarder_compute_subcomp_two_nodes(self):
         """Test a simple forwarding scenario with one additional node forwarding the data"""
@@ -231,8 +231,8 @@ class cases_NFNForwarder(object):
         fid2 = self.forwarder2.linklayer.get_or_create_fid(("127.0.0.1", self.forwarder1_port), True)
 
         # register prefixes
-        self.forwarder1.fib.add_fib_entry(Name("/lib/func"), fid1, True)
-        self.forwarder2.fib.add_fib_entry(Name("/test"), fid2, True)
+        self.forwarder1.icnlayer.add_to_fib(Name("/lib/func"), fid1, True)
+        self.forwarder2.icnlayer.add_to_fib(Name("/test"), fid2, True)
 
         # add function
         testMgmtSock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -276,7 +276,7 @@ class cases_NFNForwarder(object):
         self.assertEqual("RESULT", content.content)
         self.assertEqual(name, content.name)
         time.sleep(4)
-        self.assertEqual(len(self.forwarder1.pit.container), 0)
+        self.assertEqual(len(self.forwarder1.icnlayer.pit.container), 0)
 
     def test_NFNForwarder_compute_subcomp_two_nodes_chunking_result(self):
         """Test a simple forwarding scenario with one additional node forwarding the data"""
@@ -289,8 +289,8 @@ class cases_NFNForwarder(object):
         fid2 = self.forwarder2.linklayer.get_or_create_fid(("127.0.0.1", self.forwarder1_port), True)
 
         # register prefixes
-        self.forwarder1.fib.add_fib_entry(Name("/lib/func"), fid1, True)
-        self.forwarder2.fib.add_fib_entry(Name("/test"), fid2, True)
+        self.forwarder1.icnlayer.add_to_fib(Name("/lib/func"), fid1, True)
+        self.forwarder2.icnlayer.add_to_fib(Name("/test"), fid2, True)
 
         # add function
         testMgmtSock1 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -334,7 +334,7 @@ class cases_NFNForwarder(object):
         self.assertEqual('mdo:/lib/func/f1/_(/lib/func/f2(/test/data/object))/NFN/c0;/lib/func/f1/_(/lib/func/f2(/test/data/object))/NFN/c1;/lib/func/f1/_(/lib/func/f2(/test/data/object))/NFN/c2;/lib/func/f1/_(/lib/func/f2(/test/data/object))/NFN/c3:/lib/func/f1/_(/lib/func/f2(/test/data/object))/NFN/m1', content.content)
         self.assertEqual(name, content.name)
         time.sleep(4)
-        self.assertEqual(len(self.forwarder1.pit.container), 0)
+        self.assertEqual(len(self.forwarder1.icnlayer.pit.container), 0)
 
 class test_NFNForwarder_SimplePacketEncoder(cases_NFNForwarder, unittest.TestCase):
     """Runs tests with the SimplePacketEncoder"""

--- a/PiCN/ProgramLibs/NFNForwarder/test/test_NFNForwarder.py
+++ b/PiCN/ProgramLibs/NFNForwarder/test/test_NFNForwarder.py
@@ -13,7 +13,7 @@ from PiCN.ProgramLibs.NFNForwarder import NFNForwarder
 class cases_NFNForwarder(object):
     """Test the ICN Forwarder"""
 
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def get_encoder(self):
         """returns the encoder to be used """
 

--- a/PiCN/ProgramLibs/NFNForwarder/test/test_NFNForwarder.py
+++ b/PiCN/ProgramLibs/NFNForwarder/test/test_NFNForwarder.py
@@ -52,7 +52,8 @@ class cases_NFNForwarder(object):
         #create test content
         name = Name("/test/data/object")
         test_content = Content(name, content="HelloWorld")
-        self.assertEqual(self.forwarder1.cs.find_content_object(name).content, test_content)
+        cs_fwd1 = self.forwarder1.data_structs.get('cs')
+        self.assertEqual(cs_fwd1.find_content_object(name).content, test_content)
 
         #create interest
         interest = Interest("/test/data/object")
@@ -103,7 +104,8 @@ class cases_NFNForwarder(object):
         #create test content
         name = Name("/test/data/object")
         test_content = Content(name, content="HelloWorld")
-        self.assertEqual(self.forwarder2.cs.find_content_object(name).content, test_content)
+        cs_fwd2 = self.forwarder2.data_structs.get('cs')
+        self.assertEqual(cs_fwd2.find_content_object(name).content, test_content)
 
         #create interest
         interest = Interest("/test/data/object")
@@ -210,6 +212,7 @@ class cases_NFNForwarder(object):
         # send interest
         self.testSock.sendto(encoded_interest, ("127.0.0.1", self.forwarder1_port))
         # receive content
+        self.testSock.settimeout(3)
         encoded_content, addr = self.testSock.recvfrom(8192)
         time.sleep(0.1)
         content: Content = self.encoder.decode(encoded_content)


### PR DESCRIPTION
This Patch removes the Multiprocessing.Manager from the Datastructures within the ICNLayer, to make datastructures more resuable. 


