### PR TITLE
Added `__pycache__` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+**/__pycache__/
 build/*
 .idea/*
 .eggs/*


### PR DESCRIPTION
Not ignoring __pycache__ makes their parent directories stick around when checking out a branch that does not have those directories.https://github.com/cn-uofbasel/PiCN/compare/master...s3lph:patch-1